### PR TITLE
update runtime, CUPS and GTK

### DIFF
--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -1,8 +1,8 @@
 app-id: com.simplenote.Simplenote
 base: org.electronjs.Electron2.BaseApp
-base-version: '20.08'
+base-version: '21.08'
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: simplenote
@@ -30,8 +30,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://github.com/apple/cups/releases/download/v2.3.3/cups-2.3.3-source.tar.gz
-        sha256: 261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee
+        url: https://github.com/OpenPrinting/cups/releases/download/v2.4.2/cups-2.4.2-source.tar.gz
+        sha256: f03ccb40b087d1e30940a40e0141dcbba263f39974c20eb9f2521066c9c6c908
 
   - name: gtk-cups-backend
     buildsystem: meson
@@ -42,7 +42,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/gtk.git
-        tag: 3.24.23
+        tag: 3.24.34
   
   - name: gtk-settings
     buildsystem: simple


### PR DESCRIPTION
- [x] Update the runtime to a non-EoL version. Application will not run with 22.08, crashes immediately with `GPU process isn't usable. Goodbye.`
- [x] Update CUPS to the latest stable release and switch upstream to OpenPrinting
- [x] Update GTK to the latest 3.x release

`x-checker-data` will be added at a later date and we can look into why the application is crashing with the 22.08 runtime, these are just some trivial fixes for now.