### PR TITLE
Update to v2.22.1

### DIFF
--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -28,8 +28,8 @@ modules:
       - /include
     sources:
       - type: archive
-        url: https://github.com/OpenPrinting/cups/releases/download/v2.4.7/cups-2.4.7-source.tar.gz
-        sha256: dd54228dd903526428ce7e37961afaed230ad310788141da75cebaa08362cf6c
+        url: https://github.com/OpenPrinting/cups/releases/download/v2.4.10/cups-2.4.10-source.tar.gz
+        sha256: d75757c2bc0f7a28b02ee4d52ca9e4b1aa1ba2affe16b985854f5336940e5ad7
 
   - name: gtk-cups-backend
     buildsystem: meson
@@ -40,7 +40,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/GNOME/gtk.git
-        tag: 3.24.38
+        tag: 3.24.43
   
   - name: gtk-settings
     buildsystem: simple

--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -19,8 +19,6 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
 modules:
 
-  - shared-modules/libsecret/libsecret.json
-
   - name: libcups
     make-args: [libs]
     no-make-install: true

--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -13,7 +13,6 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=cups
-  - --filesystem=xdg-config/Simplenote
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --talk-name=org.freedesktop.secrets

--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -62,14 +62,14 @@ modules:
       - type: file
         path: com.simplenote.Simplenote.png
       - type: archive
-        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.21.0/Simplenote-linux-2.21.0-arm64.tar.gz
-        sha256: 0a82f99b73061d7583ec9dfbd49f9133f7f79c061825bfef6836687fb9374d5e
+        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.22.1/Simplenote-linux-2.22.1-arm64.tar.gz
+        sha256: 5ebe4fa34709db5b80db41cbc39006bb8370fa45336b79f6740a0381b04dce15
         only-arches:
           - aarch64
         dest: main
       - type: archive
-        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.21.0/Simplenote-linux-2.21.0-x64.tar.gz
-        sha256: e4e7482029628ce52c7a42a1cec9822785b7118aeb3f3ae4007d7da386dd1a3e
+        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.22.1/Simplenote-linux-2.22.1-x64.tar.gz
+        sha256: 131f526d9707f840b1e0346017f61a793973141f51fd5782c6d38d4600e1e975
         only-arches:
           - x86_64
         dest: main


### PR DESCRIPTION
List of changes 
- Update simplenote version
- Removed libsecret shared module (it's part of the Electron runtime now)
- Updated versions for cups and gtk-cups-backend