### PR TITLE
Update runtime version from 23.08 to 25.08 and more

### DIFF
--- a/com.simplenote.Simplenote.appdata.xml
+++ b/com.simplenote.Simplenote.appdata.xml
@@ -5,8 +5,12 @@
   <name>Simplenote</name>
   <summary>The simplest way to keep notes</summary>
   <url type="homepage">https://simplenote.com</url>
+  <url type="bugtracker">https://github.com/Automattic/simplenote-electron/issues</url>
+  <url type="vcs-browser">https://github.com/Automattic/simplenote-electron</url>
   
-  <developer_name>Automattic Inc.</developer_name>
+  <developer id="com.automattic">
+    <name>Automattic Inc.</name>
+  </developer>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0-only</project_license>
   
@@ -44,7 +48,12 @@
   </screenshots>
 
   <releases>
-    <release date="2021-10-18" version="2.21.0" /> 
+    <release date="2025-11-06" version="2.24.0" />
+    <release date="2025-03-11" version="2.23.2" />
+    <release date="2025-01-21" version="2.23.0" />
+    <release date="2024-09-24" version="2.22.2" />
+    <release date="2024-07-19" version="2.22.1" />
+    <release date="2021-10-18" version="2.21.0" />
     <release date="2021-10-04" version="2.20.0" />
     <release date="2021-09-21" version="2.19.1" />
     <release date="2021-09-20" version="2.19.0" />

--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -19,36 +19,37 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
 modules:
 
-  # - name: libcups
-  #   make-args: [libs]
-  #   no-make-install: true
-  #   post-install:
-  #     - make install-headers install-libs
-  #   cleanup:
-  #     - /include
-  #   sources:
-  #     - type: archive
-  #       url: https://github.com/OpenPrinting/cups/releases/download/v2.4.7/cups-2.4.7-source.tar.gz
-  #       sha256: dd54228dd903526428ce7e37961afaed230ad310788141da75cebaa08362cf6c
+  - name: libcups
+    make-args: [libs]
+    no-make-install: true
+    post-install:
+      - make install-headers install-libs
+    cleanup:
+      - /include
+    sources:
+      - type: archive
+        url: https://github.com/OpenPrinting/cups/releases/download/v2.4.17/cups-2.4.17-source.tar.gz
+        sha256: 89c703238de210d4f4f4e5d4269e3d60c4b2f487aad75a8a1eaecd659e4d0b77
 
-  # - name: gtk-cups-backend
-  #   buildsystem: meson
-  #   make-args: [modules/printbackends/libprintbackend-cups.so]
-  #   no-make-install: true
-  #   post-install:
-  #     - install -Dm 755 modules/printbackends/libprintbackend-cups.so -t /app/lib/gtkmodules/3.0.0/printbackends/
-  #   sources:
-  #     - type: git
-  #       url: https://gitlab.gnome.org/GNOME/gtk.git
-  #       tag: 3.24.38
-  
-  # - name: gtk-settings
-  #   buildsystem: simple
-  #   build-commands:
-  #     - install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini
-  #   sources:
-  #     - type: file
-  #       path: gtk-settings.ini
+  - name: gtk-cups-backend
+    buildsystem: meson
+    make-args: [modules/printbackends/libprintbackend-cups.so]
+    no-make-install: true
+    post-install:
+      - install -Dm 755 modules/printbackends/libprintbackend-cups.so -t /app/lib/gtkmodules/3.0.0/printbackends/
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/gtk.git
+        tag: 3.24.52
+        commit: 6a0b360d473f7c546314738c0c8dd9829eb9d3c2
+
+  - name: gtk-settings
+    buildsystem: simple
+    build-commands:
+      - install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini
+    sources:
+      - type: file
+        path: gtk-settings.ini
 
   - name: simplenote
     buildsystem: simple

--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -1,8 +1,8 @@
 app-id: com.simplenote.Simplenote
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '25.08'
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: simplenote
@@ -19,38 +19,36 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
 modules:
 
-  - shared-modules/libsecret/libsecret.json
+  # - name: libcups
+  #   make-args: [libs]
+  #   no-make-install: true
+  #   post-install:
+  #     - make install-headers install-libs
+  #   cleanup:
+  #     - /include
+  #   sources:
+  #     - type: archive
+  #       url: https://github.com/OpenPrinting/cups/releases/download/v2.4.7/cups-2.4.7-source.tar.gz
+  #       sha256: dd54228dd903526428ce7e37961afaed230ad310788141da75cebaa08362cf6c
 
-  - name: libcups
-    make-args: [libs]
-    no-make-install: true
-    post-install:
-      - make install-headers install-libs
-    cleanup:
-      - /include
-    sources:
-      - type: archive
-        url: https://github.com/OpenPrinting/cups/releases/download/v2.4.7/cups-2.4.7-source.tar.gz
-        sha256: dd54228dd903526428ce7e37961afaed230ad310788141da75cebaa08362cf6c
-
-  - name: gtk-cups-backend
-    buildsystem: meson
-    make-args: [modules/printbackends/libprintbackend-cups.so]
-    no-make-install: true
-    post-install:
-      - install -Dm 755 modules/printbackends/libprintbackend-cups.so -t /app/lib/gtkmodules/3.0.0/printbackends/
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/gtk.git
-        tag: 3.24.38
+  # - name: gtk-cups-backend
+  #   buildsystem: meson
+  #   make-args: [modules/printbackends/libprintbackend-cups.so]
+  #   no-make-install: true
+  #   post-install:
+  #     - install -Dm 755 modules/printbackends/libprintbackend-cups.so -t /app/lib/gtkmodules/3.0.0/printbackends/
+  #   sources:
+  #     - type: git
+  #       url: https://gitlab.gnome.org/GNOME/gtk.git
+  #       tag: 3.24.38
   
-  - name: gtk-settings
-    buildsystem: simple
-    build-commands:
-      - install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini
-    sources:
-      - type: file
-        path: gtk-settings.ini
+  # - name: gtk-settings
+  #   buildsystem: simple
+  #   build-commands:
+  #     - install -Dm 644 gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini
+  #   sources:
+  #     - type: file
+  #       path: gtk-settings.ini
 
   - name: simplenote
     buildsystem: simple
@@ -62,14 +60,14 @@ modules:
       - type: file
         path: com.simplenote.Simplenote.png
       - type: archive
-        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.21.0/Simplenote-linux-2.21.0-arm64.tar.gz
-        sha256: 0a82f99b73061d7583ec9dfbd49f9133f7f79c061825bfef6836687fb9374d5e
+        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.24.0/Simplenote-linux-2.24.0-arm64.tar.gz
+        sha256: 8037132f9f2aef15bd7e21a686a3a0397608daacaef8b56a3f6d134ac5ca8dd8
         only-arches:
           - aarch64
         dest: main
       - type: archive
-        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.21.0/Simplenote-linux-2.21.0-x64.tar.gz
-        sha256: e4e7482029628ce52c7a42a1cec9822785b7118aeb3f3ae4007d7da386dd1a3e
+        url: https://github.com/Automattic/simplenote-electron/releases/download/v2.24.0/Simplenote-linux-2.24.0-x64.tar.gz
+        sha256: 68ebcdd5ae98abe1ca1987e6e1c934dcfff7db663ed9c61a1116e87f98fda289
         only-arches:
           - x86_64
         dest: main

--- a/com.simplenote.Simplenote.yaml
+++ b/com.simplenote.Simplenote.yaml
@@ -13,7 +13,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=cups
-  - --filesystem=xdg-config/Simplenote
+  # - --filesystem=xdg-config/Simplenote
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --talk-name=org.freedesktop.secrets


### PR DESCRIPTION
- Update runtime to 25.08
- Update Simplenote version to 2.24.0
- Drop the libsecret module, which is already provided by the runtime
- Update cups-related modules